### PR TITLE
with-based functionality

### DIFF
--- a/Database/PostgreSQL/Simple/Streaming.hs
+++ b/Database/PostgreSQL/Simple/Streaming.hs
@@ -62,6 +62,18 @@ module Database.PostgreSQL.Simple.Streaming
 
     -- * Re-exported symbols
   , runResourceT
+    -- * Obtaining a connection
+  , connectPostgreSQL
+  , connect
+  , ConnectInfo(..)
+  , defaultConnectInfo
+  , postgreSQLConnectionString
+  , close
+    -- ** Possible exceptions
+  , QueryError(..)
+  , ResultError(..)
+  , ManyErrors(..)
+  , SqlError(..)
   ) where
 
 import Control.Exception.Safe
@@ -87,7 +99,9 @@ import qualified Database.PostgreSQL.LibPQ as LibPQ
 import Database.PostgreSQL.Simple
        (Connection, QueryError(..), ResultError(..), ToRow, FromRow,
         formatQuery, FoldOptions(..), FetchQuantity(..), execute_,
-        defaultFoldOptions, rollback, connectPostgreSQL, close)
+        defaultFoldOptions, rollback, connect, connectPostgreSQL,
+        ConnectInfo(..), defaultConnectInfo, postgreSQLConnectionString,
+        close, SqlError(..))
 import qualified Database.PostgreSQL.Simple.Copy as Pg
 import Database.PostgreSQL.Simple.FromRow (fromRow)
 import Database.PostgreSQL.Simple.Internal

--- a/Database/PostgreSQL/Simple/Streaming.hs
+++ b/Database/PostgreSQL/Simple/Streaming.hs
@@ -5,6 +5,20 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
+{- |
+
+There are two main ways to fetch data from PostgreSQL in a streaming
+fashion:
+
+1. Directly, using 'ResourceT' to manage resources.
+
+2. Using the various bracketed @with*@ functions; these play nicely
+   with @ContT@ from "Control.Monad.Trans.Cont" or - if you will be
+   running it all directly in IO with no other transformers on the
+   stack - the <http://hackage.haskell.org/package/managed managed>
+   package.
+
+-}
 module Database.PostgreSQL.Simple.Streaming
   ( -- * Obtaining a connection
     withPGConnection


### PR DESCRIPTION
In light of the discussion in michaelt/streaming#23 this adds with-style continuation parsing style variants of all functions except `copyIn`, as well as some convenience functions/re-exports.