### PR TITLE
Relax dependencies

### DIFF
--- a/streaming-postgresql-simple.cabal
+++ b/streaming-postgresql-simple.cabal
@@ -22,12 +22,12 @@ library
     exposed-modules:
         Database.PostgreSQL.Simple.Streaming
     build-depends:
-        base >=4.9 && <4.11,
+        base >=4.9 && <4.12,
         bytestring >=0.10.8.1 && <0.11,
-        exceptions >=0.8.3 && <0.9,
+        exceptions >=0.8.3 && <0.11,
         postgresql-libpq >=0.9.2.0 && <0.10,
         postgresql-simple >=0.5 && <0.6,
-        resourcet >=1.1.8.1 && <1.2,
+        resourcet >=1.1.8.1 && <1.3,
         safe-exceptions >=0.1.4.0 && <0.2,
         streaming >=0.1 && <0.3,
         transformers >=0.5.2.0 && <0.6


### PR DESCRIPTION
In particular, support GHC 8.4 (base-4.11).